### PR TITLE
Updated README.md QuickStart to show min Bicep ver

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ These steps walk through how to use NoOps to deploy a hub and spoke architecture
 * Tier 1 (T1): Infrastructure Operations, and Logging (1 vnet, 2 resource groups)
 * Tier 2 (T2): DevSecOps & Shared Services (1 vnet, 1 resource group)
 
+> **Note:** The deployment requires Bicep CLI version 0.11.1 (030248df55) or later. You can check your version by running `bicep --version`. You can upgrade by running `az bicep upgrade`.
+
 Steps:
 
 1. Clone the repository down and change directory to the `lz-platform-scca-hub-3spoke` directory


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates the README.md QuickStart section to let the reader know that Bicep CLI v0.11.1 or newer is required to run the QuickStart steps without error.  It reflects learning documented in Bug #112.

## This PR fixes/adds/changes/removes

1. Closing #112 

### Breaking Changes
None

## Testing Evidence

Documentation update.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/NoOpsAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/NoOpsAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/NoOpsAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
