### PR TITLE
121 the windows server was created not following the naming convention

### DIFF
--- a/src/bicep/azresources/Modules/Microsoft.Compute/virtualmachines/az.com.virtual.machine.bicep
+++ b/src/bicep/azresources/Modules/Microsoft.Compute/virtualmachines/az.com.virtual.machine.bicep
@@ -1,7 +1,8 @@
 /* Copyright (c) Microsoft Corporation. Licensed under the MIT license. */
 // Main resource
 @description('Optional. The name of the virtual machine to be created. You should use a unique prefix to reduce name collisions in Active Directory. If no value is provided, a 10 character long unique string will be generated based on the Resource Group\'s name.')
-param name string = take(toLower(uniqueString(resourceGroup().name)), 10)
+param name string = ''
+param vmName string = take(toLower(uniqueString(name, resourceGroup().name)), 10)
 
 @description('Optional. Specifies whether the computer names should be transformed. The transformation is performed on all computer names. Available transformations are \'none\' (Default), \'uppercase\' and \'lowercase\'.')
 @allowed([
@@ -362,7 +363,7 @@ module vm_nic 'includes/az.com.virtual.machine.network.Interface.bicep' = [for (
 }]
 
 resource vm 'Microsoft.Compute/virtualMachines@2021-07-01' = {
-  name: name
+  name: vmName
   location: location
   identity: identity
   tags: tags
@@ -383,7 +384,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2021-07-01' = {
     storageProfile: {
       imageReference: imageReference
       osDisk: {
-        name: '${name}-disk-os-01'
+        name: '${vmName}-disk-os-01'
         createOption: contains(osDisk, 'createOption') ? osDisk.createOption : 'FromImage'
         deleteOption: contains(osDisk, 'deleteOption') ? osDisk.deleteOption : 'Delete'
         diskSizeGB: osDisk.diskSizeGB
@@ -395,7 +396,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2021-07-01' = {
       }
       dataDisks: [for (dataDisk, index) in dataDisks: {
         lun: index
-        name: '${name}-disk-data-${padLeft((index + 1), 2, '0')}'
+        name: '${vmName}-disk-data-${padLeft((index + 1), 2, '0')}'
         diskSizeGB: dataDisk.diskSizeGB
         createOption: contains(dataDisk, 'createOption') ? dataDisk.createOption : 'Empty'
         deleteOption: contains(dataDisk, 'deleteOption') ? dataDisk.deleteOption : 'Delete'

--- a/src/bicep/azresources/Modules/Microsoft.ContainerService/managedClusters/rbac/roleAssignments.bicep
+++ b/src/bicep/azresources/Modules/Microsoft.ContainerService/managedClusters/rbac/roleAssignments.bicep
@@ -1,3 +1,11 @@
+// ----------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. Licensed under the MIT license.
+//
+// THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, 
+// EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+// OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+// ----------------------------------------------------------------------------------
+
 @sys.description('Required. The IDs of the principals to assign the role to.')
 param principalIds array
 

--- a/src/bicep/enclaves/enclave-scca-hub3spoke-aks/parameters/deploy.parameters.json
+++ b/src/bicep/enclaves/enclave-scca-hub3spoke-aks/parameters/deploy.parameters.json
@@ -20,7 +20,7 @@
     },
     "parHub": {
       "value": {
-        "subscriptionId": "896f5276-df9a-4317-a791-469396bef7fa",
+        "subscriptionId": "<<subscriptionId>>",
         "virtualNetworkAddressPrefix": "10.0.100.0/24",
         "subnetAddressPrefix": "10.0.100.128/27",
         "subnets": [

--- a/src/bicep/overlays/management-services/bastion/deploy.bicep
+++ b/src/bicep/overlays/management-services/bastion/deploy.bicep
@@ -319,9 +319,20 @@ module modLinuxNetworkInterface '../../../azresources/Modules/Microsoft.Network/
   }
 }
 
+
+module modLinuxAvSet '../../../azresources/Modules/Microsoft.Compute/availabilitySets/az.com.availabilty.set.bicep' = {
+  name: 'deploy-ra-lx-avset-${parLocation}-${parDeploymentNameSuffix}'
+  params: {
+    name: '${take(toLower(uniqueString(resourceGroup().name)), 10)}-linux-avset'
+    location: parLocation
+    availabilitySetSku: 'Aligned'
+  }
+}
+
 module modLinuxVirtualMachine '../../../azresources/Modules/Microsoft.Compute/virtualmachines/az.com.virtual.machine.bicep' = if (parRemoteAccess.bastion.linux.enable) {
   name: 'deploy-ra-linux-vm-${parLocation}-${parDeploymentNameSuffix}'
-  params: {    
+  params: {   
+    name: parRemoteAccess.bastion.linux.vmName 
     location: parLocation
     tags: (empty(parTags)) ? modTags : parTags
 
@@ -330,7 +341,7 @@ module modLinuxVirtualMachine '../../../azresources/Modules/Microsoft.Compute/vi
     adminPassword: parRemoteAccess.bastion.linux.vmAdminPasswordOrKey
 
     diagnosticWorkspaceId: parLogAnalyticsWorkspaceId
-    availabilitySetResourceId:modAvSet.outputs.resourceId
+    availabilitySetResourceId:modLinuxAvSet.outputs.resourceId
     encryptionAtHost: parRemoteAccess.bastion.encryptionAtHost
     imageReference: {
       offer: parRemoteAccess.bastion.linux.vmImageOffer
@@ -381,10 +392,10 @@ module modWindowsNetworkInterface '../../../azresources/Modules/Microsoft.Networ
   }
 }
 
-module modAvSet '../../../azresources/Modules/Microsoft.Compute/availabilitySets/az.com.availabilty.set.bicep' = {
+module modWinAvSet '../../../azresources/Modules/Microsoft.Compute/availabilitySets/az.com.availabilty.set.bicep' = {
   name: 'deploy-ra-win-avset-${parLocation}-${parDeploymentNameSuffix}'
   params: {
-    name: '${toLower(parRequired.orgPrefix)}-${parRemoteAccess.bastion.windows.vmName}-avset'
+    name: '${take(toLower(uniqueString(resourceGroup().name)), 10)}-windows-avset'
     location: parLocation
     availabilitySetSku: 'Aligned'
   }
@@ -392,14 +403,15 @@ module modAvSet '../../../azresources/Modules/Microsoft.Compute/availabilitySets
 
 module modWindowsVirtualMachine '../../../azresources/Modules/Microsoft.Compute/virtualmachines/az.com.virtual.machine.bicep' = if (parRemoteAccess.bastion.windows.enable) {
   name: 'deploy-ra-windows-vm-${parLocation}-${parDeploymentNameSuffix}'
-  params: {    
+  params: {  
+    name: parRemoteAccess.bastion.windows.vmName  
     location: parLocation
     tags: (empty(parTags)) ? modTags : parTags
 
     adminUsername: parRemoteAccess.bastion.windows.vmAdminUsername
     adminPassword: parRemoteAccess.bastion.windows.vmAdminPassword //kv.getSecret('WindowsVmAdminPassword')
     diagnosticWorkspaceId: parLogAnalyticsWorkspaceId
-    availabilitySetResourceId:modAvSet.outputs.resourceId
+    availabilitySetResourceId:modWinAvSet.outputs.resourceId
     encryptionAtHost: parRemoteAccess.bastion.encryptionAtHost
     imageReference: {
       offer: parRemoteAccess.bastion.windows.vmImageOffer

--- a/src/bicep/overlays/management-services/bastion/deploy.bicep
+++ b/src/bicep/overlays/management-services/bastion/deploy.bicep
@@ -321,8 +321,7 @@ module modLinuxNetworkInterface '../../../azresources/Modules/Microsoft.Network/
 
 module modLinuxVirtualMachine '../../../azresources/Modules/Microsoft.Compute/virtualmachines/az.com.virtual.machine.bicep' = if (parRemoteAccess.bastion.linux.enable) {
   name: 'deploy-ra-linux-vm-${parLocation}-${parDeploymentNameSuffix}'
-  params: {
-    name: '${toLower(parRequired.orgPrefix)}-${toLower(parRemoteAccess.bastion.linux.vmName)}'
+  params: {    
     location: parLocation
     tags: (empty(parTags)) ? modTags : parTags
 
@@ -393,8 +392,7 @@ module modAvSet '../../../azresources/Modules/Microsoft.Compute/availabilitySets
 
 module modWindowsVirtualMachine '../../../azresources/Modules/Microsoft.Compute/virtualmachines/az.com.virtual.machine.bicep' = if (parRemoteAccess.bastion.windows.enable) {
   name: 'deploy-ra-windows-vm-${parLocation}-${parDeploymentNameSuffix}'
-  params: {
-    name: parRemoteAccess.bastion.windows.vmName
+  params: {    
     location: parLocation
     tags: (empty(parTags)) ? modTags : parTags
 

--- a/src/bicep/overlays/management-services/bastion/parameters/deploy.parameters.json
+++ b/src/bicep/overlays/management-services/bastion/parameters/deploy.parameters.json
@@ -38,8 +38,7 @@
                     "publicIPAddressAvailabilityZones": [],
                     "encryptionAtHost": false,
                     "linux": {
-                        "enable": true,
-                        "vmName": "bastion-linux",
+                        "enable": true,                        
                         "vmAdminUsername": "azureuser",
                         "disablePasswordAuthentication": false,
                         "vmAdminPasswordOrKey": "Rem0te@2020246",
@@ -53,8 +52,7 @@
                         "networkInterfacePrivateIPAddressAllocationMethod": "Dynamic"
                     },
                     "windows": {
-                        "enable": true,
-                        "vmName": "bastion-windows",
+                        "enable": true,                        
                         "vmAdminUsername": "azureuser",
                         "vmAdminPassword": "Rem0te@2020246",
                         "vmSize": "Standard_DS1_v2",

--- a/src/bicep/overlays/management-services/bastion/parameters/deploy.parameters.json
+++ b/src/bicep/overlays/management-services/bastion/parameters/deploy.parameters.json
@@ -38,7 +38,8 @@
                     "publicIPAddressAvailabilityZones": [],
                     "encryptionAtHost": false,
                     "linux": {
-                        "enable": true,                        
+                        "enable": true,
+                        "vmName": "bastion-linux",
                         "vmAdminUsername": "azureuser",
                         "disablePasswordAuthentication": false,
                         "vmAdminPasswordOrKey": "Rem0te@2020246",
@@ -52,7 +53,8 @@
                         "networkInterfacePrivateIPAddressAllocationMethod": "Dynamic"
                     },
                     "windows": {
-                        "enable": true,                        
+                        "enable": true,
+                        "vmName": "bastion-windows",
                         "vmAdminUsername": "azureuser",
                         "vmAdminPassword": "Rem0te@2020246",
                         "vmSize": "Standard_DS1_v2",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
1. The windows/Linux server was created not following the naming convention in deploying the resources because the naming convention would have conflicts based on other regions.  So changed the name of the virtual machine to be created. Use a unique prefix to reduce name collisions in Active Directory. A 10-character long unique string will be generated based on the Resource Group\'s name. See Below:

param name string = '' <-- This need to updated by "vmName": in parameters
param vmName string = take(toLower(uniqueString(name, resourceGroup().name)), 10)

2. Add AVSets to both Windows and Linux

## This PR fixes/adds/changes/removes

1. closes #121 

### Breaking Changes

None

## Testing Evidence

All resources deployed successfully.

## As part of this Pull Request, I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/NoOpsAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/NoOpsAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/NoOpsAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
