### PR TITLE
fix: storage deployment type error

### DIFF
--- a/src/bicep/azresources/Modules/Microsoft.Storage/storageAccounts/az.data.storage.bicep
+++ b/src/bicep/azresources/Modules/Microsoft.Storage/storageAccounts/az.data.storage.bicep
@@ -170,8 +170,8 @@ var supportsFileService = storageAccountKind == 'FileStorage' || storageAccountK
 var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
 var identity = identityType != 'None' ? {
   type: identityType
-  userAssignedIdentities: !empty(userAssignedIdentities) ? userAssignedIdentities : {}
-} : {}
+  userAssignedIdentities: !empty(userAssignedIdentities) ? userAssignedIdentities : null
+} : null
 
 resource keyVault 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = if (!empty(cMKKeyVaultResourceId)) {
   name: last(split(cMKKeyVaultResourceId, '/'))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

reverts a previous change to the identity object that caused a missing json type error to occur. Further information in issue 226 and issue 218

https://github.com/Azure/NoOpsAccelerator/issues/226
https://github.com/Azure/NoOpsAccelerator/issues/218

## This PR fixes/adds/changes/removes

1. changes the construct of the object created to define the identity variable. 

### Breaking Changes

N/A

## Testing Evidence

Deployed the bicep file individually and as part of a landing zone deployment. 
Build the bicep file and checked json output, no additional issues occured.
See issue 226

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/NoOpsAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/NoOpsAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/NoOpsAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
