### PR TITLE
Fix the spelling of parameter in the Demonstration 1 training docs.

### DIFF
--- a/docs/training/terraform/Demonstration 1 - Incrementally Deploy Enclave.md
+++ b/docs/training/terraform/Demonstration 1 - Incrementally Deploy Enclave.md
@@ -130,7 +130,7 @@ $location = [your region]
 
     - parAssignableScopeManagementGroupId: **ANOA** (if you are not using the default, change to the name of your intermediate management group)
 
-1.  Issue the command updating the **--management-group-id** paramter to your intermediate management group name or **ANOA** as the default
+1.  Issue the command updating the **--management-group-id** parameter to your intermediate management group name or **ANOA** as the default
 
     **Azure CLI**
     ``` PowerShell


### PR DESCRIPTION
This change fixes the spelling of a misspelled word found in `Demonstration 1 - Incrementally Deploy Enclave` training documentation.

In `docs/training/terraform/Demonstration 1 - Incrementally Deploy Enclave.md`, a misspelled word `paramter` has been corrected to `parameter`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/parameter).